### PR TITLE
Fix .center & .landing from not properly filling vertical height

### DIFF
--- a/front_end/js/App.js
+++ b/front_end/js/App.js
@@ -6,6 +6,7 @@ import ShowModels from './ShowModels'
 import LeftNavigation from './LeftNavigation'
 import defaultLeftNavButtons from '../config/defaultLeftNavButtons'
 import TopNavigation from './TopNavigation'
+import UnderDevelopment from './UnderDevelopment'
 import apiSettings from '../config/apiSettings'
 import '../public/less/main.less'
 
@@ -116,6 +117,9 @@ const App = React.createClass({
                 checkVisible={this.checkVisible}
                 {...props} />
             }} />
+          <Match pattern='/admin/:page'
+            component={() => <UnderDevelopment />}
+          />
         </div>
       </div>
     )

--- a/front_end/js/UnderDevelopment.js
+++ b/front_end/js/UnderDevelopment.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const UnderDevelopment = () => {
+  return (
+    <div className='center'>
+      Under Development
+    </div>
+  )
+}
+
+export default UnderDevelopment

--- a/front_end/public/less/Landing.less
+++ b/front_end/public/less/Landing.less
@@ -1,5 +1,7 @@
 .landing {
   background: #f2f2f2;
+  height: 100vh;
+  margin-bottom: -56px;
 }
 .side-bar {
   height: 100vh;

--- a/front_end/public/less/main.less
+++ b/front_end/public/less/main.less
@@ -62,6 +62,7 @@ h1, h2, h3, h4, h5 {
   padding: 0 15px;
   padding-bottom: 100px;
   min-height: 100vh;
+  margin-bottom: -56px;
 }
 
 .width-override {


### PR DESCRIPTION
* Add height: 100vh & margin-bottom: -56px (top nav offset) to .landing
* Add margin-bottom: -56px to .center

Additional:
* Add UnderDevelopment.js and use for Users and & Reports